### PR TITLE
Bottom Navbar overflow fix

### DIFF
--- a/src/styles/BottomNavigationBar/BottomNavigationBar.module.scss
+++ b/src/styles/BottomNavigationBar/BottomNavigationBar.module.scss
@@ -1,6 +1,9 @@
 @use "@/styles/partials/variables" as var;
 
 .navigationBar {
+    position: fixed;
+    bottom: 0;
+    left: 0;
     display: flex;
     flex-shrink: 0;
     height: var.$BottomNavigationBar-height;

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -55,13 +55,11 @@ body {
   background-color: var.$petal-white;
   color: var.$off-black;
 }
+
 body .mainWrapper {
   flex-grow: 1;
   overflow: auto;
-}
-
-main {
-  position: relative;
+  margin-bottom: calc(var.$BottomNavigationBar-height + 1rem);
 }
 
 h1 {


### PR DESCRIPTION
Tried fixing the bottom nav bar by adding a navbar that has the same size as the botton nav bar _(With some additional padding)_. This results in the following effect: https://jam.dev/c/0af6e0e9-5d33-4688-a950-df0cf502661e